### PR TITLE
feat: replace markdown-table with tabled for proper column alignment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -517,6 +517,7 @@ To keep history clean and reviews manageable:
   * `feat(scope): message`
   * `fix(scope): message`
   * `refactor: message`
+* Commits should only have a title, no body/description.
 * Before opening a commit, run at least:
   * `just fmt`
   * `just lint`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,12 +71,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +178,12 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytes"
@@ -1070,16 +1070,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "markdown-table"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f418a49329ec3474d51712a08850681aff718aef4c807e8e2dc043ce6b83066f"
-dependencies = [
- "anyhow",
- "pad",
-]
-
-[[package]]
 name = "marked-yaml"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,11 +1243,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "pad"
-version = "0.1.6"
+name = "papergrid"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
 dependencies = [
+ "bytecount",
+ "fnv",
  "unicode-width",
 ]
 
@@ -1385,6 +1377,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1966,7 +1980,6 @@ dependencies = [
  "dirs",
  "futures",
  "itertools",
- "markdown-table",
  "marked-yaml",
  "mockall",
  "rand",
@@ -1977,6 +1990,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "tabled",
  "tar",
  "thiserror",
  "tokio",
@@ -2009,6 +2023,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2037,6 +2075,15 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -2388,9 +2435,9 @@ checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1970,7 +1970,7 @@ dependencies = [
 
 [[package]]
 name = "sysdig-lsp"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-trait",
  "bollard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,9 +175,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytecount"
@@ -193,9 +193,9 @@ checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cc"
-version = "1.2.47"
+version = "1.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd405d82c84ff7f35739f175f67d8b9fb7687a0e84ccdc78bd3568839827cf07"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -209,9 +209,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -223,9 +223,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -233,9 +233,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -257,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "fnv"
@@ -560,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
@@ -589,9 +589,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -599,7 +599,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -771,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
 dependencies = [
  "base64",
  "bytes",
@@ -882,9 +882,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -896,9 +896,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -949,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -967,9 +967,9 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "iri-string"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -992,15 +992,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1014,19 +1014,19 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags 2.10.0",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -1052,9 +1052,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lsp-types"
@@ -1104,9 +1104,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "wasi",
@@ -1271,7 +1271,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1403,18 +1403,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -1447,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
@@ -1464,12 +1464,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror",
 ]
@@ -1531,9 +1540,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
@@ -1560,7 +1569,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -1577,7 +1586,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1624,9 +1633,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags 2.10.0",
  "errno",
@@ -1637,9 +1646,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1650,9 +1659,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.13.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
+checksum = "4910321ebe4151be888e35fe062169554e74aad01beafed60410131420ceffbc"
 dependencies = [
  "zeroize",
 ]
@@ -1676,9 +1685,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
 
 [[package]]
 name = "scc"
@@ -1712,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9558e172d4e8533736ba97870c4b2cd63f84b382a3d6eb063da41b91cce17289"
+checksum = "54e910108742c57a770f492731f99be216a52fadd361b06c8fb59d74ccc267d2"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -1795,15 +1804,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1831,17 +1840,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.16.0"
+version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10574371d41b0d9b2cff89418eda27da52bcaff2cc8741db26382a77c29131f1"
+checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "schemars 0.9.0",
- "schemars 1.1.0",
+ "schemars 1.2.0",
  "serde_core",
  "serde_json",
  "time",
@@ -1849,12 +1858,13 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
 dependencies = [
  "fslock",
- "futures",
+ "futures-executor",
+ "futures-util",
  "log",
  "once_cell",
  "parking_lot",
@@ -1864,9 +1874,9 @@ dependencies = [
 
 [[package]]
 name = "serial_test_derive"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1890,10 +1900,11 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -1939,9 +1950,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2059,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
@@ -2116,30 +2127,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
@@ -2157,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "bytes",
  "libc",
@@ -2205,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2218,20 +2229,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.7"
+version = "0.23.10+spec-1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6485ef6d0d9b5d0ec17244ff7eb05310113c3f316f2d14200d4de56b3cb98f8d"
+checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
 dependencies = [
- "indexmap 2.12.1",
+ "indexmap 2.13.0",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -2239,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
 dependencies = [
  "winnow",
 ]
@@ -2262,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2277,9 +2288,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
@@ -2288,7 +2299,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.2",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
 ]
@@ -2341,9 +2352,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -2352,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2363,9 +2374,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -2384,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -2447,14 +2458,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -2483,9 +2495,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "want"
@@ -2504,18 +2516,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2526,11 +2538,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.55"
+version = "0.4.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
+checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -2539,9 +2552,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2549,9 +2562,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -2562,18 +2575,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.82"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
+checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2829,18 +2842,18 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
@@ -2894,18 +2907,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "668f5168d10b9ee831de31933dc111a459c97ec93225beb307aed970d1372dfd"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "2c7962b26b0a8685668b671ee4b54d007a67d4eaf05fda79ac0ecf41e32270f1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2971,3 +2984,9 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ clap = { version = "4.5.34", features = ["derive"] }
 dirs = "6.0.0"
 futures = "0.3.31"
 itertools = "0.14.0"
-markdown-table = "0.2.0"
+tabled = "0.20.0"
 marked-yaml = { version = "0.8.0", features = ["serde"] }
 rand = "0.9.0"
 regex = "1.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysdig-lsp"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 authors = [ "Sysdig Inc." ]
 readme = "README.md"

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1763934636,
-        "narHash": "sha256-9glbI7f1uU+yzQCq5LwLgdZqx6svOhZWkd4JRY265fc=",
+        "lastModified": 1768395095,
+        "narHash": "sha256-ZhuYJbwbZT32QA95tSkXd9zXHcdZj90EzHpEXBMabaw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ee09932cedcef15aaf476f9343d1dea2cb77e261",
+        "rev": "13868c071cc73a5e9f610c47d7bb08e5da64fdd5",
         "type": "github"
       },
       "original": {

--- a/src/app/markdown/markdown_data.rs
+++ b/src/app/markdown/markdown_data.rs
@@ -303,47 +303,44 @@ mod test {
 * **Digest**: `sha256:5a828e28de105c3d7821c4442f0f5d1c52dc16acf4999d5f31a3bc0f03f06edd`
 * **BaseOS**: ubuntu 23.04
 
-| TOTAL VULNS FOUND | CRITICAL | HIGH | MEDIUM      | LOW         | NEGLIGIBLE |
-| :-------------: | :----: | :-: | :---------: | :---------: | :------: |
-| 11              | 0      | 0   | 9 (9 Fixable) | 2 (2 Fixable) | 0        |
-
+| TOTAL VULNS FOUND | CRITICAL | HIGH |    MEDIUM     |      LOW      | NEGLIGIBLE |
+|-------------------|----------|------|---------------|---------------|------------|
+|        11         |    0     |  0   | 9 (9 Fixable) | 2 (2 Fixable) |     0      |
 
 ### Fixable Packages
-| PACKAGE          | TYPE | VERSION              | SUGGESTED FIX        | CRITICAL | HIGH | MEDIUM | LOW | NEGLIGIBLE | EXPLOIT |
-| :--------------- | :-: | :------------------- | :------------------- | :----: | :-: | :--: | :-: | :------: | :---: |
-| libgnutls30      | os  | 3.7.8-5ubuntu1.1     | 3.7.8-5ubuntu1.2     | -      | -   | 2    | -   | -        | -     |
-| libc-bin         | os  | 2.37-0ubuntu2.1      | 2.37-0ubuntu2.2      | -      | -   | 1    | 1   | -        | -     |
-| libc6            | os  | 2.37-0ubuntu2.1      | 2.37-0ubuntu2.2      | -      | -   | 1    | 1   | -        | -     |
-| libpam-modules   | os  | 1.5.2-5ubuntu1       | 1.5.2-5ubuntu1.1     | -      | -   | 1    | -   | -        | -     |
-| libpam-modules-bin | os  | 1.5.2-5ubuntu1       | 1.5.2-5ubuntu1.1     | -      | -   | 1    | -   | -        | -     |
-| libpam-runtime   | os  | 1.5.2-5ubuntu1       | 1.5.2-5ubuntu1.1     | -      | -   | 1    | -   | -        | -     |
-| libpam0g         | os  | 1.5.2-5ubuntu1       | 1.5.2-5ubuntu1.1     | -      | -   | 1    | -   | -        | -     |
-| tar              | os  | 1.34+dfsg-1.2ubuntu0.1 | 1.34+dfsg-1.2ubuntu0.2 | -      | -   | 1    | -   | -        | -     |
-
+| PACKAGE            | TYPE | VERSION                | SUGGESTED FIX          | CRITICAL | HIGH | MEDIUM | LOW | NEGLIGIBLE | EXPLOIT |
+|--------------------|------|------------------------|------------------------|----------|------|--------|-----|------------|---------|
+| libgnutls30        |  os  | 3.7.8-5ubuntu1.1       | 3.7.8-5ubuntu1.2       |    -     |  -   |   2    |  -  |     -      |    -    |
+| libc-bin           |  os  | 2.37-0ubuntu2.1        | 2.37-0ubuntu2.2        |    -     |  -   |   1    |  1  |     -      |    -    |
+| libc6              |  os  | 2.37-0ubuntu2.1        | 2.37-0ubuntu2.2        |    -     |  -   |   1    |  1  |     -      |    -    |
+| libpam-modules     |  os  | 1.5.2-5ubuntu1         | 1.5.2-5ubuntu1.1       |    -     |  -   |   1    |  -  |     -      |    -    |
+| libpam-modules-bin |  os  | 1.5.2-5ubuntu1         | 1.5.2-5ubuntu1.1       |    -     |  -   |   1    |  -  |     -      |    -    |
+| libpam-runtime     |  os  | 1.5.2-5ubuntu1         | 1.5.2-5ubuntu1.1       |    -     |  -   |   1    |  -  |     -      |    -    |
+| libpam0g           |  os  | 1.5.2-5ubuntu1         | 1.5.2-5ubuntu1.1       |    -     |  -   |   1    |  -  |     -      |    -    |
+| tar                |  os  | 1.34+dfsg-1.2ubuntu0.1 | 1.34+dfsg-1.2ubuntu0.2 |    -     |  -   |   1    |  -  |     -      |    -    |
 
 ### Policy Evaluation
 
-| POLICY                              | STATUS | FAILURES | RISKS ACCEPTED |
-| :---------------------------------- | :--: | :----: | :----------: |
-| carholder policy - pk               | ❌   | 1      | 0            |
-| Critical Vulnerability Found        | ✅   | 0      | 0            |
-| Forbid Secrets in Images            | ✅   | 0      | 0            |
-| NIST SP 800-Star                    | ❌   | 14     | 0            |
-| PolicyCardHolder                    | ❌   | 1      | 0            |
-| Sensitive Information or Secret Found | ✅   | 0      | 0            |
-| Sysdig Best Practices               | ✅   | 0      | 0            |
-
+| POLICY                                | STATUS | FAILURES | RISKS ACCEPTED |
+|---------------------------------------|--------|----------|----------------|
+| carholder policy - pk                 |   ❌   |    1     |       0        |
+| Critical Vulnerability Found          |   ✅   |    0     |       0        |
+| Forbid Secrets in Images              |   ✅   |    0     |       0        |
+| NIST SP 800-Star                      |   ❌   |    14    |       0        |
+| PolicyCardHolder                      |   ❌   |    1     |       0        |
+| Sensitive Information or Secret Found |   ✅   |    0     |       0        |
+| Sysdig Best Practices                 |   ✅   |    0     |       0        |
 
 ### Vulnerability Detail
 
-| VULN CVE     | SEVERITY | PACKAGES | FIXABLE | EXPLOITABLE | ACCEPTED RISK |
-| :----------- | :----- | :----- | :---- | :-------- | :---------- |
-| CVE-2023-39804 | Medium | 1      | ✅    | ❌        | ❌          |
-| CVE-2023-4806 | Low    | 2      | ✅    | ❌        | ❌          |
-| CVE-2023-5156 | Medium | 2      | ✅    | ❌        | ❌          |
-| CVE-2024-0553 | Medium | 1      | ✅    | ❌        | ❌          |
-| CVE-2024-0567 | Medium | 1      | ✅    | ❌        | ❌          |
-| CVE-2024-22365 | Medium | 4      | ✅    | ❌        | ❌          |"#;
+| VULN CVE       | SEVERITY | PACKAGES | FIXABLE | EXPLOITABLE | ACCEPTED RISK |
+|----------------|----------|----------|---------|-------------|---------------|
+| CVE-2023-39804 | Medium   | 1        | ✅      | ❌          | ❌            |
+| CVE-2023-4806  | Low      | 2        | ✅      | ❌          | ❌            |
+| CVE-2023-5156  | Medium   | 2        | ✅      | ❌          | ❌            |
+| CVE-2024-0553  | Medium   | 1        | ✅      | ❌          | ❌            |
+| CVE-2024-0567  | Medium   | 1        | ✅      | ❌          | ❌            |
+| CVE-2024-22365 | Medium   | 4        | ✅      | ❌          | ❌            |"#;
 
         assert_eq!(
             markdown_data.to_string().trim(),

--- a/src/app/markdown/markdown_fixable_package_table.rs
+++ b/src/app/markdown/markdown_fixable_package_table.rs
@@ -3,7 +3,10 @@ use std::{
     sync::Arc,
 };
 
-use markdown_table::{Heading, HeadingAlignment, MarkdownTable};
+use tabled::{
+    builder::Builder,
+    settings::{Alignment, Style, object::Columns},
+};
 
 use crate::domain::scanresult::{layer::Layer, scan_result::ScanResult, severity::Severity};
 
@@ -111,69 +114,68 @@ impl Display for FixablePackageTable {
             return f.write_str("");
         }
 
-        let headers = vec![
-            Heading::new("PACKAGE".to_string(), Some(HeadingAlignment::Left)),
-            Heading::new("TYPE".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("VERSION".to_string(), Some(HeadingAlignment::Left)),
-            Heading::new("SUGGESTED FIX".to_string(), Some(HeadingAlignment::Left)),
-            Heading::new("CRITICAL".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("HIGH".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("MEDIUM".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("LOW".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("NEGLIGIBLE".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("EXPLOIT".to_string(), Some(HeadingAlignment::Center)),
-        ];
+        let mut builder = Builder::default();
+        builder.push_record([
+            "PACKAGE",
+            "TYPE",
+            "VERSION",
+            "SUGGESTED FIX",
+            "CRITICAL",
+            "HIGH",
+            "MEDIUM",
+            "LOW",
+            "NEGLIGIBLE",
+            "EXPLOIT",
+        ]);
 
-        let data = self
-            .0
-            .iter()
-            .map(|p| {
-                vec![
-                    p.name.clone(),
-                    p.package_type.clone(),
-                    p.version.clone(),
-                    p.suggested_fix.clone().unwrap_or_default(),
-                    if p.vulnerabilities.critical > 0 {
-                        p.vulnerabilities.critical.to_string()
-                    } else {
-                        "-".to_string()
-                    },
-                    if p.vulnerabilities.high > 0 {
-                        p.vulnerabilities.high.to_string()
-                    } else {
-                        "-".to_string()
-                    },
-                    if p.vulnerabilities.medium > 0 {
-                        p.vulnerabilities.medium.to_string()
-                    } else {
-                        "-".to_string()
-                    },
-                    if p.vulnerabilities.low > 0 {
-                        p.vulnerabilities.low.to_string()
-                    } else {
-                        "-".to_string()
-                    },
-                    if p.vulnerabilities.negligible > 0 {
-                        p.vulnerabilities.negligible.to_string()
-                    } else {
-                        "-".to_string()
-                    },
-                    if p.exploits > 0 {
-                        p.exploits.to_string()
-                    } else {
-                        "-".to_string()
-                    },
-                ]
-            })
-            .collect();
+        for p in &self.0 {
+            builder.push_record([
+                p.name.clone(),
+                p.package_type.clone(),
+                p.version.clone(),
+                p.suggested_fix.clone().unwrap_or_default(),
+                if p.vulnerabilities.critical > 0 {
+                    p.vulnerabilities.critical.to_string()
+                } else {
+                    "-".to_string()
+                },
+                if p.vulnerabilities.high > 0 {
+                    p.vulnerabilities.high.to_string()
+                } else {
+                    "-".to_string()
+                },
+                if p.vulnerabilities.medium > 0 {
+                    p.vulnerabilities.medium.to_string()
+                } else {
+                    "-".to_string()
+                },
+                if p.vulnerabilities.low > 0 {
+                    p.vulnerabilities.low.to_string()
+                } else {
+                    "-".to_string()
+                },
+                if p.vulnerabilities.negligible > 0 {
+                    p.vulnerabilities.negligible.to_string()
+                } else {
+                    "-".to_string()
+                },
+                if p.exploits > 0 {
+                    p.exploits.to_string()
+                } else {
+                    "-".to_string()
+                },
+            ]);
+        }
 
-        let mut table = MarkdownTable::new(data);
-        table.with_headings(headers);
+        let mut table = builder.build();
+        table
+            .with(Style::markdown())
+            // TYPE column (index 1) centered
+            .modify(Columns::new(1..=1), Alignment::center())
+            // Severity columns (4-8) and EXPLOIT (9) centered
+            .modify(Columns::new(4..=9), Alignment::center());
 
-        let format = format!(
-            "\n### Fixable Packages\n{}",
-            table.as_markdown().unwrap_or_default()
-        );
+        let format = format!("\n### Fixable Packages\n{}", table);
 
         f.write_str(&format)
     }

--- a/src/app/markdown/markdown_policy_evaluated_table.rs
+++ b/src/app/markdown/markdown_policy_evaluated_table.rs
@@ -1,7 +1,10 @@
 use std::fmt::{Display, Formatter};
 
 use itertools::Itertools;
-use markdown_table::{Heading, HeadingAlignment, MarkdownTable};
+use tabled::{
+    builder::Builder,
+    settings::{Alignment, Style, object::Columns},
+};
 
 use crate::domain::scanresult::scan_result::ScanResult;
 
@@ -22,33 +25,25 @@ impl Display for PolicyEvaluatedTable {
             return f.write_str("");
         }
 
-        let headers = vec![
-            Heading::new("POLICY".to_string(), Some(HeadingAlignment::Left)),
-            Heading::new("STATUS".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("FAILURES".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("RISKS ACCEPTED".to_string(), Some(HeadingAlignment::Center)),
-        ];
+        let mut builder = Builder::default();
+        builder.push_record(["POLICY", "STATUS", "FAILURES", "RISKS ACCEPTED"]);
 
-        let data = self
-            .0
-            .iter()
-            .map(|p| {
-                vec![
-                    p.name.clone(),
-                    if p.passed { "✅" } else { "❌" }.to_string(),
-                    p.failures.to_string(),
-                    p.risks_accepted.to_string(),
-                ]
-            })
-            .collect();
+        for p in &self.0 {
+            builder.push_record([
+                p.name.clone(),
+                if p.passed { "✅" } else { "❌" }.to_string(),
+                p.failures.to_string(),
+                p.risks_accepted.to_string(),
+            ]);
+        }
 
-        let mut table = MarkdownTable::new(data);
-        table.with_headings(headers);
+        let mut table = builder.build();
+        table
+            .with(Style::markdown())
+            // STATUS, FAILURES, RISKS ACCEPTED columns (1-3) centered
+            .modify(Columns::new(1..=3), Alignment::center());
 
-        let format = format!(
-            "\n### Policy Evaluation\n\n{}",
-            table.as_markdown().unwrap_or_default()
-        );
+        let format = format!("\n### Policy Evaluation\n\n{}", table);
 
         f.write_str(&format)
     }

--- a/src/app/markdown/markdown_summary_table.rs
+++ b/src/app/markdown/markdown_summary_table.rs
@@ -1,6 +1,9 @@
 use std::fmt::{Display, Formatter};
 
-use markdown_table::{Heading, HeadingAlignment, MarkdownTable};
+use tabled::{
+    builder::Builder,
+    settings::{Alignment, Style},
+};
 
 use crate::domain::scanresult::{scan_result::ScanResult, severity::Severity};
 
@@ -67,18 +70,6 @@ impl From<&ScanResult> for MarkdownSummaryTable {
 
 impl Display for MarkdownSummaryTable {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let headers = vec![
-            Heading::new(
-                "TOTAL VULNS FOUND".to_string(),
-                Some(HeadingAlignment::Center),
-            ),
-            Heading::new("CRITICAL".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("HIGH".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("MEDIUM".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("LOW".to_string(), Some(HeadingAlignment::Center)),
-            Heading::new("NEGLIGIBLE".to_string(), Some(HeadingAlignment::Center)),
-        ];
-
         let summary_vulns_line = |total_vulns: u32, fixable_vulns: u32| {
             if fixable_vulns > 0 {
                 format!("{} ({} Fixable)", total_vulns, fixable_vulns)
@@ -87,18 +78,27 @@ impl Display for MarkdownSummaryTable {
             }
         };
 
-        let data = vec![vec![
+        let mut builder = Builder::default();
+        builder.push_record([
+            "TOTAL VULNS FOUND",
+            "CRITICAL",
+            "HIGH",
+            "MEDIUM",
+            "LOW",
+            "NEGLIGIBLE",
+        ]);
+        builder.push_record([
             self.total_found.to_string(),
             summary_vulns_line(self.critical, self.critical_fixable),
             summary_vulns_line(self.high, self.high_fixable),
             summary_vulns_line(self.medium, self.medium_fixable),
             summary_vulns_line(self.low, self.low_fixable),
             summary_vulns_line(self.negligible, self.negligible_fixable),
-        ]];
+        ]);
 
-        let mut table = MarkdownTable::new(data);
-        table.with_headings(headers);
+        let mut table = builder.build();
+        table.with(Style::markdown()).with(Alignment::center());
 
-        f.write_str(&table.as_markdown().unwrap_or_default())
+        f.write_str(&table.to_string())
     }
 }

--- a/src/app/markdown/markdown_vulnerability_evaluated_table.rs
+++ b/src/app/markdown/markdown_vulnerability_evaluated_table.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use itertools::Itertools;
-use markdown_table::{Heading, HeadingAlignment, MarkdownTable};
+use tabled::{builder::Builder, settings::Style};
 
 use crate::domain::scanresult::{layer::Layer, scan_result::ScanResult};
 
@@ -82,37 +82,31 @@ impl Display for VulnerabilityEvaluatedTable {
             return f.write_str("");
         }
 
-        let headers = vec![
-            Heading::new("VULN CVE".to_string(), Some(HeadingAlignment::Left)),
-            Heading::new("SEVERITY".to_string(), Some(HeadingAlignment::Left)),
-            Heading::new("PACKAGES".to_string(), Some(HeadingAlignment::Left)),
-            Heading::new("FIXABLE".to_string(), Some(HeadingAlignment::Left)),
-            Heading::new("EXPLOITABLE".to_string(), Some(HeadingAlignment::Left)),
-            Heading::new("ACCEPTED RISK".to_string(), Some(HeadingAlignment::Left)),
-        ];
+        let mut builder = Builder::default();
+        builder.push_record([
+            "VULN CVE",
+            "SEVERITY",
+            "PACKAGES",
+            "FIXABLE",
+            "EXPLOITABLE",
+            "ACCEPTED RISK",
+        ]);
 
-        let data = self
-            .0
-            .iter()
-            .map(|v| {
-                vec![
-                    v.cve.clone(),
-                    v.severity.clone(),
-                    v.packages_found.to_string(),
-                    if v.fixable { "✅" } else { "❌" }.to_string(),
-                    if v.exploitable { "✅" } else { "❌" }.to_string(),
-                    if v.accepted_risk { "✅" } else { "❌" }.to_string(),
-                ]
-            })
-            .collect();
+        for v in &self.0 {
+            builder.push_record([
+                v.cve.clone(),
+                v.severity.clone(),
+                v.packages_found.to_string(),
+                if v.fixable { "✅" } else { "❌" }.to_string(),
+                if v.exploitable { "✅" } else { "❌" }.to_string(),
+                if v.accepted_risk { "✅" } else { "❌" }.to_string(),
+            ]);
+        }
 
-        let mut table = MarkdownTable::new(data);
-        table.with_headings(headers);
+        let mut table = builder.build();
+        table.with(Style::markdown());
 
-        let format = format!(
-            "\n### Vulnerability Detail\n\n{}",
-            table.as_markdown().unwrap_or_default()
-        );
+        let format = format!("\n### Vulnerability Detail\n\n{}", table);
 
         f.write_str(&format)
     }

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -396,24 +396,21 @@ async fn test_hover(
 * **Digest**: `sha256:67890`
 * **BaseOS**: alpine:3.18
 
-| TOTAL VULNS FOUND | CRITICAL | HIGH        | MEDIUM | LOW | NEGLIGIBLE |
-| :-------------: | :----: | :---------: | :--: | :-: | :------: |
-| 1               | 0      | 1 (1 Fixable) | 0    | 0   | 0        |
-
+| TOTAL VULNS FOUND | CRITICAL |     HIGH      | MEDIUM | LOW | NEGLIGIBLE |
+|-------------------|----------|---------------|--------|-----|------------|
+|         1         |    0     | 1 (1 Fixable) |   0    |  0  |     0      |
 
 ### Fixable Packages
-| PACKAGE | TYPE | VERSION | SUGGESTED FIX | CRITICAL | HIGH | MEDIUM | LOW | NEGLIGIBLE | EXPLOIT |
-| :----- | :-: | :---- | :---------- | :----: | :-: | :--: | :-: | :------: | :---: |
-| package1 | os  | 1.0.0 | 1.0.1       | -      | 1   | -    | -   | -        | -     |
-
+| PACKAGE  | TYPE | VERSION | SUGGESTED FIX | CRITICAL | HIGH | MEDIUM | LOW | NEGLIGIBLE | EXPLOIT |
+|----------|------|---------|---------------|----------|------|--------|-----|------------|---------|
+| package1 |  os  | 1.0.0   | 1.0.1         |    -     |  1   |   -    |  -  |     -      |    -    |
 
 
 ### Vulnerability Detail
 
-| VULN CVE    | SEVERITY | PACKAGES | FIXABLE | EXPLOITABLE | ACCEPTED RISK |
-| :---------- | :----- | :----- | :---- | :-------- | :---------- |
-| CVE-2021-1234 | High   | 1      | ✅    | ❌        | ❌          |
-"#;
+| VULN CVE      | SEVERITY | PACKAGES | FIXABLE | EXPLOITABLE | ACCEPTED RISK |
+|---------------|----------|----------|---------|-------------|---------------|
+| CVE-2021-1234 | High     | 1        | ✅      | ❌          | ❌            |"#;
 
     let expected_json = serde_json::json!({
         "contents": {


### PR DESCRIPTION
Replace markdown-table crate with tabled 0.20.0 to fix table rendering issues where separator lines did not align with column widths.

The tabled crate properly calculates column widths and generates aligned markdown tables with correct separator characters.