### PR TITLE
build: Revert naersk, restore rustPlatform for cross-compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,7 +2029,7 @@ dependencies = [
 
 [[package]]
 name = "sysdig-lsp"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "async-trait",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysdig-lsp"
-version = "0.8.4"
+version = "0.8.5"
 edition = "2024"
 authors = [ "Sysdig Inc." ]
 readme = "README.md"

--- a/flake.lock
+++ b/flake.lock
@@ -1,27 +1,5 @@
 {
   "nodes": {
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "naersk",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1752475459,
-        "narHash": "sha256-z6QEu4ZFuHiqdOPbYss4/Q8B0BFhacR8ts6jO/F/aOU=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "bf0d6f70f4c9a9cf8845f992105652173f4b617f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -40,48 +18,13 @@
         "type": "github"
       }
     },
-    "naersk": {
-      "inputs": {
-        "fenix": "fenix",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1777031541,
-        "narHash": "sha256-KZ4s1kolHXFQrRGlnB503gDcTrVQMhiczO+LvvwKEPg=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "5e73301621274c44798bf6c6211ed27fc2ced201",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1752077645,
-        "narHash": "sha256-HM791ZQtXV93xtCY+ZxG1REzhQenSQO020cu6rHtAPk=",
+        "lastModified": 1778124196,
+        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "be9e214982e20b8310878ac2baa063a961c1bdf6",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1778036283,
-        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
         "type": "github"
       },
       "original": {
@@ -94,25 +37,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1752428706,
-        "narHash": "sha256-EJcdxw3aXfP8Ex1Nm3s0awyH9egQvB2Gu+QEnJn2Sfg=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "591e3b7624be97e4443ea7b5542c191311aa141d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,19 +2,16 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    naersk.url = "github:nix-community/naersk"; # Allows rust build caching
   };
   outputs =
     {
       self,
       nixpkgs,
       flake-utils,
-      naersk,
     }:
     let
       overlays.default = final: prev: {
         sysdig-lsp = prev.callPackage ./package.nix { };
-        naersk = prev.callPackage naersk { };
       };
 
       flake = flake-utils.lib.eachDefaultSystem (

--- a/package.nix
+++ b/package.nix
@@ -1,5 +1,5 @@
 {
-  naersk,
+  rustPlatform,
   pkgsStatic,
   lib,
   stdenv,
@@ -9,10 +9,13 @@
 let
   cargoFile = builtins.fromTOML (builtins.readFile ./Cargo.toml);
 in
-naersk.buildPackage {
+rustPlatform.buildRustPackage {
   pname = cargoFile.package.name;
   version = cargoFile.package.version;
   src = ./.;
+  cargoLock = {
+    lockFile = ./Cargo.lock;
+  };
 
   nativeBuildInputs = [
     pkg-config


### PR DESCRIPTION
Naersk was introduced as an experiment for Nix build caching but doesn't handle cross-builds well, which we need for the release workflow. Reverts to nixpkgs' `rustPlatform.buildRustPackage` and bumps to 0.8.5.