### PR TITLE
chore: drop darwin-amd64 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,6 @@ jobs:
           - runner: macos-latest
             os: darwin
             arch: arm64
-          - runner: macos-latest
-            os: darwin
-            arch: amd64
           # - runner: ubuntu-latest # Not supported by the CLI Scanner yet
           #   os: windows
           #   arch: amd64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "sysdig-lsp"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "async-trait",
  "bollard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sysdig-lsp"
-version = "0.8.6"
+version = "0.8.7"
 edition = "2024"
 authors = [ "Sysdig Inc." ]
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ The easiest way to install Sysdig LSP is to download a pre-built binary from the
 1. **Download the binary for your platform:**
    - Linux x86_64: `sysdig-lsp-linux-amd64`
    - Linux ARM64: `sysdig-lsp-linux-arm64`
-   - macOS x86_64 (Intel): `sysdig-lsp-darwin-amd64`
    - macOS ARM64 (Apple Silicon): `sysdig-lsp-darwin-arm64`
+
+   > **Note:** macOS x86_64 (Intel) is no longer supported since Nixpkgs dropped the `x86_64-darwin` cross-compilation target. The last release with a `sysdig-lsp-darwin-amd64` binary is [0.8.5](https://github.com/sysdiglabs/sysdig-lsp/releases/tag/0.8.5).
 
 2. **Make it executable and move to your PATH:**
    ```bash
@@ -105,7 +106,6 @@ The following binaries are built:
 
 - Linux x86_64: `nix build .#sysdig-lsp-linux-amd64`
 - Linux aarch64: `nix build .#sysdig-lsp-linux-arm64`
-- Darwin x86_64: `nix build .#sysdig-lsp-darwin-amd64`
 - Darwin aarch64: `nix build .#sysdig-lsp-darwin-arm64`
 
 Windows is not yet supported because the Sysdig CLI Scanner is not releasing a .exe for now, but you can still build it with `nix build .#sysdig-lsp-windows-amd64`

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,6 @@
 
             sysdig-lsp-linux-amd64 = pkgsCross.gnu64.pkgsStatic.sysdig-lsp;
             sysdig-lsp-linux-arm64 = pkgsCross.aarch64-multiplatform.pkgsStatic.sysdig-lsp;
-            sysdig-lsp-darwin-amd64 = pkgsCross.x86_64-darwin.sysdig-lsp;
             sysdig-lsp-darwin-arm64 = pkgsCross.aarch64-darwin.sysdig-lsp;
             sysdig-lsp-windows-amd64 = pkgsCross.mingwW64.sysdig-lsp;
           };


### PR DESCRIPTION
Nixpkgs dropped the `x86_64-darwin` cross-compilation target, breaking the release build for macOS Intel. Removing the target from the flake and release matrix so releases stop failing.

Last release shipping a `sysdig-lsp-darwin-amd64` binary is 0.8.5. Bumps to 0.8.7 to cut a new release.